### PR TITLE
Fix middleware execution order for Celebrate validation errors

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,11 +34,11 @@ app.use(locationsRoutes);
 app.use(feedbackRoutes);
 app.use(categoriesRoutes);
 
-//Middleware - 404 - Route not found
-app.use(notFoundHandler);
-
 //Middleware - Celebrate error catching
 app.use(errors());
+
+//Middleware - 404 - Route not found
+app.use(notFoundHandler);
 
 //Middleware - Error catching
 app.use(errorHandler);


### PR DESCRIPTION
Move the celebrate error handler middleware before the 404 handler to ensure validation errors are properly caught and formatted instead of being incorrectly handled as route-not-found errors.

Issue: Query parameter validation failures (e.g., missing page, perPage) were returning generic 404 responses instead of validation error details.

Changes: Reordered middleware in `server.js` to sequence error handlers correctly:

- Routes
- Celebrate errors handler
- 404 handler
- Global error handler